### PR TITLE
update docker-aio for Payara 6 #8305

### DIFF
--- a/conf/docker-aio/0prep_deps.sh
+++ b/conf/docker-aio/0prep_deps.sh
@@ -4,9 +4,9 @@ if [ ! -d dv/deps ]; then
 fi
 wdir=`pwd`
 
-if [ ! -e dv/deps/payara-5.2021.6.zip ]; then
+if [ ! -e dv/deps/payara-6.2022.1.Alpha2.zip ]; then
 	echo "payara dependency prep"
-	wget https://s3-eu-west-1.amazonaws.com/payara.fish/Payara+Downloads/5.2021.6/payara-5.2021.6.zip  -O dv/deps/payara-5.2021.6.zip
+	wget https://s3.eu-west-1.amazonaws.com/payara.fish/Payara+Downloads/6.2022.1.Alpha2/payara-6.2022.1.Alpha2.zip -O dv/deps/payara-6.2022.1.Alpha2.zip
 fi
 
 if [ ! -e dv/deps/solr-8.11.1dv.tgz ]; then

--- a/conf/docker-aio/c8.dockerfile
+++ b/conf/docker-aio/c8.dockerfile
@@ -24,11 +24,11 @@ COPY disableipv6.conf /etc/sysctl.d/
 RUN rm /etc/httpd/conf/*
 COPY httpd.conf /etc/httpd/conf 
 RUN cd /opt ; tar zxf /tmp/dv/deps/solr-8.11.1dv.tgz
-RUN cd /opt ; unzip /tmp/dv/deps/payara-5.2021.6.zip ; ln -s /opt/payara5 /opt/glassfish4
+RUN cd /opt ; unzip /tmp/dv/deps/payara-6.2022.1.Alpha2.zip
 
 # this copy of domain.xml is the result of running `asadmin set server.monitoring-service.module-monitoring-levels.jvm=LOW` on a default glassfish installation (aka - enable the glassfish REST monitir endpoint for the jvm`
 # this dies under Java 11, do we keep it?
-#COPY domain-restmonitor.xml /opt/payara5/glassfish/domains/domain1/config/domain.xml
+#COPY domain-restmonitor.xml /opt/payara6/glassfish/domains/domain1/config/domain.xml
 
 RUN sudo -u postgres /usr/pgsql-13/bin/initdb -D /var/lib/pgsql/13/data -E 'UTF-8'
 
@@ -58,8 +58,6 @@ EXPOSE 9009
 
 RUN mkdir /opt/dv
 
-# keeping the symlink on the off chance that something else is still assuming /usr/local/glassfish4
-RUN ln -s /opt/payara5 /usr/local/glassfish4
 COPY dv/install/ /opt/dv/
 COPY install.bash /opt/dv/
 COPY entrypoint.bash /opt/dv/

--- a/conf/docker-aio/configure_doi.bash
+++ b/conf/docker-aio/configure_doi.bash
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-cd /opt/payara5
+cd /opt/payara6
 
 # if appropriate; reconfigure PID provider on the basis of environmental variables.
 if [ ! -z "${DoiProvider}" ]; then

--- a/conf/docker-aio/setupIT.bash
+++ b/conf/docker-aio/setupIT.bash
@@ -7,7 +7,9 @@ unzip dvinstall.zip
 cd /opt/dv/testdata
 ./scripts/deploy/phoenix.dataverse.org/prep
 ./db.sh
+echo "Calling install (bash script) from setupIT.bash..."
 ./install # modified from phoenix
-/usr/local/glassfish4/glassfish/bin/asadmin deploy /opt/dv/dvinstall/dataverse.war
+/opt/payara6/glassfish/bin/asadmin deploy /opt/dv/dvinstall/dataverse.war
+echo "Calling post (bash script) from setupIT.bash..."
 ./post # modified from phoenix
 

--- a/conf/docker-aio/seturl.bash
+++ b/conf/docker-aio/seturl.bash
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-docker exec dv /usr/local/glassfish4/bin/asadmin create-jvm-options "\"-Ddataverse.siteUrl=http\://localhost\:8084\""
+docker exec dv /opt/payara6/bin/asadmin create-jvm-options "\"-Ddataverse.siteUrl=http\://localhost\:8084\""

--- a/conf/docker-aio/testscripts/install
+++ b/conf/docker-aio/testscripts/install
@@ -1,7 +1,8 @@
 #!/bin/sh
+echo "Calling testscripts/install..."
 export HOST_ADDRESS=localhost
-export GLASSFISH_ROOT=/opt/payara5
-export FILES_DIR=/opt/payara5/glassfish/domains/domain1/files
+export GLASSFISH_ROOT=/opt/payara6
+export FILES_DIR=/opt/payara6/glassfish/domains/domain1/files
 export DB_NAME=dvndb
 export DB_PORT=5432
 export DB_HOST=localhost

--- a/conf/docker-aio/testscripts/post
+++ b/conf/docker-aio/testscripts/post
@@ -3,6 +3,8 @@ cd scripts/api
 ./setup-all.sh --insecure -p=admin1 | tee /tmp/setup-all.sh.out
 cd ../..
 psql -U dvnapp dvndb -f doc/sphinx-guides/source/_static/util/createsequence.sql
+echo "exiting post script early (not publishing root collection etc.)"
+exit
 scripts/search/tests/publish-dataverse-root
 #git checkout scripts/api/data/dv-root.json
 scripts/search/tests/grant-authusers-add-on-root


### PR DESCRIPTION
I've been testing payara-6.2022.1.Alpha2 (the latest) in docker-aio and these are the changes I need to run `conf/docker-aio/prep_it.bash` to attempt to spin up Dataverse.

I say "attempt to" because further changes are required to the code to get the war file to deploy. It might make more sense to make that pull request against develop rather than this "jakarta" branch. For details on that issue:

- https://github.com/IQSS/dataverse/issues/8714